### PR TITLE
A lot of additions after the hackathon!

### DIFF
--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -61,8 +61,8 @@
           "if": "steps.cache.outputs.cache-hit != 'true'"
         },
         {
-          "name": "Change dist to Ultralisp",
-          "run": "echo 'dist ultralisp http://dist.ultralisp.org' > qlfile",
+          "name": "Change dist to Ultralisp if qlfile does not exist",
+          "run": "if [[ ! -e qlfile ]]; then echo 'dist ultralisp http://dist.ultralisp.org' > qlfile; fi",
           "shell": "bash"
         },
         {
@@ -72,7 +72,7 @@
         },
         {
           "name": "Install SBLint wrapper",
-          "run": "qlot exec ros install 40ants-linter",
+          "run": "qlot exec ros install 40ants-asdf-system 40ants-linter",
           "shell": "bash"
         },
         {

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,8 +34,8 @@
           }
         },
         {
-          "name": "Change dist to Ultralisp",
-          "run": "echo 'dist ultralisp http://dist.ultralisp.org' > qlfile",
+          "name": "Change dist to Ultralisp if qlfile does not exist",
+          "run": "if [[ ! -e qlfile ]]; then echo 'dist ultralisp http://dist.ultralisp.org' > qlfile; fi",
           "shell": "bash"
         },
         {
@@ -45,7 +45,7 @@
         },
         {
           "name": "Install SBLint wrapper",
-          "run": "qlot exec ros install 40ants-linter",
+          "run": "qlot exec ros install 40ants-asdf-system 40ants-linter",
           "shell": "bash"
         },
         {

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -61,8 +61,8 @@
           "if": "steps.cache.outputs.cache-hit != 'true'"
         },
         {
-          "name": "Change dist to Ultralisp",
-          "run": "echo 'dist ultralisp http://dist.ultralisp.org' > qlfile",
+          "name": "Change dist to Ultralisp if qlfile does not exist",
+          "run": "if [[ ! -e qlfile ]]; then echo 'dist ultralisp http://dist.ultralisp.org' > qlfile; fi",
           "shell": "bash"
         },
         {
@@ -72,7 +72,7 @@
         },
         {
           "name": "Install SBLint wrapper",
-          "run": "qlot exec ros install 40ants-linter",
+          "run": "qlot exec ros install 40ants-asdf-system 40ants-linter",
           "shell": "bash"
         },
         {
@@ -89,16 +89,6 @@
           "os": [
             "ubuntu-latest",
             "macos-latest"
-          ],
-          "lisp": [
-            "sbcl-bin",
-            "ccl-bin/1.12.1"
-          ],
-          "exclude": [
-            {
-              "os": "ubuntu-latest",
-              "lisp": "ccl-bin/1.12.1"
-            }
           ]
         }
       },
@@ -106,7 +96,7 @@
       "env": {
         "OS": "${{ matrix.os }}",
         "QUICKLISP_DIST": "ultralisp",
-        "LISP": "${{ matrix.lisp }}"
+        "LISP": "sbcl-bin"
       },
       "steps": [
         {
@@ -130,7 +120,7 @@
           "uses": "actions/cache@v3",
           "with": {
             "path": "qlfile\nqlfile.lock\n~/.cache/common-lisp/\n~/.roswell\n/usr/local/etc/roswell\n/usr/local/bin/ros\n/usr/local/Cellar/roswell\n.qlot",
-            "key": "a-${{ steps.current-month.outputs.value }}-${{ env.cache-name }}-${{ matrix.os }}-ultralisp-${{ matrix.lisp }}-${{ hashFiles('qlfile.lock', '*.asd') }}"
+            "key": "a-${{ steps.current-month.outputs.value }}-${{ env.cache-name }}-${{ matrix.os }}-ultralisp-sbcl-bin-${{ hashFiles('qlfile.lock', '*.asd') }}"
           }
         },
         {

--- a/docs/changelog.lisp
+++ b/docs/changelog.lisp
@@ -16,7 +16,8 @@
          "
 ## Changes
 
-- OPENRPC-SERVER/CLACK:MAKE-CLACK-APP now is a generic-function.
+- OPENRPC-SERVER/CLACK:MAKE-CLACK-APP now is a generic-function and it requires API instance as a first argument.
+  Previously API instance was optional.
 
 ## Additions
 

--- a/docs/changelog.lisp
+++ b/docs/changelog.lisp
@@ -9,7 +9,26 @@
                               "ASDF"
                               "API"
                               "CL"
+                              "HTTP"
+                              "JSON"
                               "OSX"))
+  (0.5.0 2023-05-27
+         "
+## Changes
+
+- OPENRPC-SERVER/CLACK:MAKE-CLACK-APP now is a generic-function.
+
+## Additions
+
+- Added a way to modify Clack middlewares applied to the app. This way you can add your own middlewares or routes to your application. See details in the OPENRPC-SERVER/CLACK:APP-MIDDLEWARES generic-function documentation.
+- Added OPENRPC-SERVER/CLACK:DEBUG-ON and OPENRPC-SERVER/CLACK:DEBUG-OFF functions. They turn on support for `X-Debug-On` HTTP header. Use this header to turn on interative debugger only for choosen requests.
+- Added generic-function OPENRPC-SERVER/INTERFACE:SLOTS-TO-EXCLUDE which allows to list some slots to be hidden from all data-structures. For example, you might want to exclude password-hashes or some other sensitive information.
+- Added support for `(MEMBER :foo :bar ...)` datatype. Such objects are represented as string with enum values in JSON schema.
+
+# Fixes
+
+- Fixes type of the next-page key in the response of paginated methods.
+")
   (0.4.0 2022-11-07
          "- Fixed usage of default API when api is not specified to define-rpc-method macro.
           - Fixed most imports.")

--- a/docs/index.lisp
+++ b/docs/index.lisp
@@ -36,6 +36,8 @@
                                    "SQL"
                                    "WHERE"
                                    "LIMIT"
+                                   "SBCL"
+                                   "CCL"
                                    "JSON"
                                    "JSON-SCHEMA"
                                    "API"

--- a/example/server.lisp
+++ b/example/server.lisp
@@ -15,7 +15,8 @@
                 #:make-clack-app)
   (:export
    #:start
-   #:stop))
+   #:stop
+   #:pets-api))
 (in-package #:openrpc-example/server)
 
 (defvar *server* nil)
@@ -58,13 +59,16 @@
        (apply #'max (hash-table-keys *pets*)))))
 
 
-(openrpc-server:define-rpc-method list-pets (&key (limit 10) page-key)
+(openrpc-server:define-api (pets-api :title "Pets API"))
+
+
+(openrpc-server:define-rpc-method (pets-api list-pets) (&key (limit 10) page-key)
   (:param limit integer)
   (:param page-key integer)
   (:result (paginated-list-of pet))
   (let* ((pets (hash-table-values *pets*))
          (sorted-pets (progn ;; (break)
-                             (sort pets #'< :key #'pet-id)))
+                        (sort pets #'< :key #'pet-id)))
          (page-key (or page-key
                        -1)))
     (loop with num-found = 0
@@ -95,7 +99,7 @@
                           results))))))
 
 
-(openrpc-server:define-rpc-method create-pet (name tag)
+(openrpc-server:define-rpc-method (pets-api create-pet) (name tag)
   (:param name string)
   (:param tag string)
   (:result pet)
@@ -109,7 +113,7 @@
     pet))
 
 
-(openrpc-server:define-rpc-method get-pet (id)
+(openrpc-server:define-rpc-method (pets-api get-pet) (id)
   (:param id integer)
   (:result pet)
   (let ((pet (gethash id *pets*)))

--- a/openrpc-tests.asd
+++ b/openrpc-tests.asd
@@ -4,7 +4,8 @@
   :class :package-inferred-system
   :pathname "t"
   :depends-on ("hamcrest"
-               "openrpc-tests/petshop")
+               "openrpc-tests/petshop"
+               "openrpc-tests/server/interface")
   :description "Test system for OPENRPC."
 
   :perform (test-op (op c)

--- a/qlfile.lock
+++ b/qlfile.lock
@@ -1,8 +1,8 @@
 ("quicklisp" .
  (:class qlot/source/dist:source-dist
   :initargs (:distribution "http://beta.quicklisp.org/dist/quicklisp.txt" :%version :latest)
-  :version "2022-11-07"))
+  :version "2023-02-15"))
 ("ultralisp" .
  (:class qlot/source/dist:source-dist
   :initargs (:distribution "http://dist.ultralisp.org" :%version :latest)
-  :version "20230116100001"))
+  :version "20230527230000"))

--- a/server/ci.lisp
+++ b/server/ci.lisp
@@ -28,11 +28,13 @@
                       ;; "quicklisp"
                       "ultralisp")
           :lisp ("sbcl-bin"
-                 "ccl-bin/1.12.1")
-          :exclude ((:os "ubuntu-latest"
-                         ;; On Ubuntu tests fail with this error:
-                         ;; The condition Address family for hostname not supported (error #-9) during nameserver operation in getaddrinfo occurred with errno: 0.
-                     :lisp "ccl-bin/1.12.1"))
+                 ;; On CCL there are some strange network errors both on ubuntu and OSX
+                 ;; "ccl-bin/1.12.1"
+                 )
+          ;; :exclude ((:os "ubuntu-latest"
+          ;;                ;; On Ubuntu tests fail with this error:
+          ;;                ;; The condition Address family for hostname not supported (error #-9) during nameserver operation in getaddrinfo occurred with errno: 0.
+          ;;            :lisp "ccl-bin/1.12.1"))
           :coverage t
           :qlfile "{% ifequal quicklisp_dist \"ultralisp\" %}
                    dist ultralisp http://dist.ultralisp.org

--- a/server/clack.lisp
+++ b/server/clack.lisp
@@ -21,6 +21,10 @@
                 #:method-thunk)
   (:import-from #:websocket-driver
                 #:websocket-p)
+  ;; On CCL prometheus.cl does not load propertly
+  ;; See this issue:
+  ;; https://github.com/deadtrickster/prometheus.cl/issues/2
+  #-ccl
   (:import-from #:clack-prometheus
                 #:with-prometheus-stats)
   (:import-from #:clack-cors
@@ -76,6 +80,7 @@
                    define an :around method which will inject or replace a middleware or original app.
 
                    Default method defines two middlewares with keys :CORS and :PROMETHEUS.
+                   (Prometheus middleware works on SBCL but not on CCL).
                    To wrap these middlewares, add your middlewares to the end of the list.
                    To add your middleware inside the stack - push it to the front."))
 
@@ -166,7 +171,10 @@
     (list
      :debug #'process-debug-header
      :cors #'cors-middleware
-     :prometheus #'with-prometheus-stats)))
+     #-ccl
+     :prometheus
+     #-ccl
+     #'with-prometheus-stats)))
 
 
 (defun debug-on ()

--- a/server/docs.lisp
+++ b/server/docs.lisp
@@ -9,7 +9,11 @@
                 #:type-to-schema
                 #:transform-result
                 #:primitive-type-p
-                #:make-clack-app))
+                #:make-clack-app
+                #:debug-off
+                #:debug-on
+                #:slots-to-exclude
+                #:app-middlewares))
 (in-package #:openrpc-server/docs)
 
 
@@ -255,4 +259,8 @@ For our example project it will looks like:
   (primitive-type-p generic-function)
   (make-info generic-function)
   (return-error function)
-  (make-clack-app function))
+  (make-clack-app generic-function)
+  (app-middlewares generic-function)
+  (debug-on function)
+  (debug-off function)
+  (slots-to-exclude generic-function))

--- a/server/method.lisp
+++ b/server/method.lisp
@@ -2,6 +2,7 @@
   (:use #:cl)
   (:import-from #:log)
   (:import-from #:serapeum
+                #:merge-tables
                 #:soft-list-of
                 #:fmt
                 #:dict)

--- a/server/method.lisp
+++ b/server/method.lisp
@@ -255,12 +255,26 @@
   (let ((wrapper-body
           (cond
             (paginated-result
-             `(multiple-value-bind (result next-page-key)
+             `(multiple-value-bind (result next-page-key additional-keys)
                   ,call-form
                 (let ((response (dict "items" (transform-result result))))
                   (when next-page-key
                     (setf (gethash "next_page_key" response)
                           next-page-key))
+                  ;; Third value is used to extend results dict by adding it's
+                  ;; keys to it:
+                  (when additional-keys
+                    (check-type additional-keys hash-table)
+                    (loop for key being the hash-key of additional-keys
+                          using (hash-value value)
+                          when (nth-value 1 (gethash key response))
+                          ;; TODO: разобраться почему не выравнивается
+                          do (error "Result already has key with name \"~A\"."
+                                    key)
+                          do (setf (gethash key response)
+                                   value))
+                    (setf response
+                          (merge-tables response additional-keys)))
                   response)))
             (t
              `(transform-result ,call-form)))))

--- a/server/server.lisp
+++ b/server/server.lisp
@@ -4,10 +4,14 @@
                 #:define-rpc-method)
   (:import-from #:openrpc-server/interface
                 #:type-to-schema
+                #:slots-to-exclude
                 #:transform-result
                 #:primitive-type-p
                 #:make-info)
   (:import-from #:openrpc-server/clack
+                #:debug-off
+                #:debug-on
+                #:app-middlewares
                 #:make-clack-app)
   (:import-from #:openrpc-server/errors
                 #:return-error)
@@ -24,14 +28,20 @@
            #:primitive-type-p
            #:make-info
            #:return-error
+           ;; From Clack
            #:make-clack-app
+           #:debug-off
+           #:debug-on
+           #:app-middlewares
            ;; From Api
            #:define-api
            #:*current-api*
            #:api
            #:api-version
            #:api-title
-           #:api-methods))
+           #:api-methods
+           ;; From interface
+           #:slots-to-exclude))
 (in-package #:openrpc-server)
 
 

--- a/t/petshop.lisp
+++ b/t/petshop.lisp
@@ -6,7 +6,8 @@
                 #:testing
                 #:ok
                 #:deftest)
-  (:import-from #:openrpc-server)
+  (:import-from #:openrpc-server
+                #:define-api)
   (:import-from #:openrpc-server/clack
                 #:make-clack-app)
   (:import-from #:clack.test
@@ -21,6 +22,7 @@
                 #:*default-special-bindings*)
   (:import-from #:openrpc-example)
   (:import-from #:openrpc-example/server
+                #:pets-api
                 #:*pets*))
 (in-package #:openrpc-tests/petshop)
 
@@ -41,7 +43,7 @@
 (deftest test-pet-shop-example
   (with-empty-pet-store ()
     (testing-app "Checking PetShop"
-        (make-clack-app)
+        (make-clack-app pets-api)
       (let* ((url (localhost "/openrpc.json"))
              (test-package (make-package "test-package1" :use (list :cl)))
              (api-symbol (intern "PETSHOP" test-package)))

--- a/t/server/interface.lisp
+++ b/t/server/interface.lisp
@@ -1,0 +1,33 @@
+(uiop:define-package #:openrpc-tests/server/interface
+  (:use #:cl)
+  (:import-from #:hamcrest/rove
+                #:contains
+                #:assert-that)
+  (:import-from #:rove
+                #:testing
+                #:ok
+                #:deftest)
+  (:import-from #:openrpc-server
+                #:type-to-schema)
+  (:import-from #:serapeum
+                #:fmt)
+  (:import-from #:hamcrest/matchers
+                #:has-hash-entries))
+(in-package #:openrpc-tests/server/interface)
+
+
+(deftest test-simple-types-schema ()
+  (testing "Schema for integer"
+    (assert-that (type-to-schema 'integer)
+                 (has-hash-entries "type" "integer")))
+
+  (testing "Schema for string"
+    (assert-that (type-to-schema 'string)
+                 (has-hash-entries "type" "string"))))
+
+
+(deftest test-member-renders-as-enum ()
+  (testing "When I use MEMBER in type, then it is transformed to enum."
+    (assert-that (type-to-schema '(member :place :flowers :catering))
+                 (has-hash-entries "type" "string"
+                                   "enum" (list "PLACE" "FLOWERS" "CATERING")))))


### PR DESCRIPTION
- OPENRPC-SERVER/CLACK:MAKE-CLACK-APP now is a generic-function.

- Added a way to modify Clack middlewares applied to the app. This way you can add your own middlewares or routes to your application. See details in the OPENRPC-SERVER/CLACK:APP-MIDDLEWARES generic-function documentation.
- Added OPENRPC-SERVER/CLACK:DEBUG-ON and OPENRPC-SERVER/CLACK:DEBUG-OFF functions. They turn on support for `X-Debug-On` HTTP header. Use this header to turn on interative debugger only for choosen requests.
- Added generic-function OPENRPC-SERVER/INTERFACE:SLOTS-TO-EXCLUDE which allows to list some slots to be hidden from all data-structures. For example, you might want to exclude password-hashes or some other sensitive information.
- Added support for `(MEMBER :foo :bar ...)` datatype. Such objects are represented as string with enum values in JSON schema.

- Fixes type of the next-page key in the response of paginated methods.