### PR TITLE
Fix: use mop for describe-object method

### DIFF
--- a/client/core.lisp
+++ b/client/core.lisp
@@ -25,27 +25,57 @@
 
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  (defun generate-method-description (spec)
-    (let* ((original-name (gethash "name" spec))
-           (name (intern (normalize-name original-name)))
-           (params-spec (gethash "params" spec))
-           (lambda-list (generate-lambda-list params-spec)))
-      `(format stream "- ~S~%"
-               ',(cons name
-                       lambda-list))))
+  (declaim (ftype (function (closer-mop:specializer stream) null)
+		  generate-method-descriptions))
+  (defun generate-method-descriptions (class stream)
+    (flet ((proper-lambda-list (method)
+             (let* ((lambda-list (closer-mop:method-lambda-list method))
+                    (specializers (closer-mop:method-specializers method))
+                    (list-element 0)
+                    (method-name (intern (symbol-name
+                                          (closer-mop:generic-function-name
+                                           (closer-mop:method-generic-function method)))))
+                    (lambda-list-parameters
+                      (mapcar (lambda (element)
+                                (let ((type
+                                        (nth (incf list-element) specializers)))
+                                  (if type
+                                      (list (intern (symbol-name element))
+                                            (intern (symbol-name (class-name type))))
+                                      (typecase element
+                                        (symbol
+                                         (intern (symbol-name element)))
+                                        (cons
+                                         (mapcar (lambda (item)
+                                                   (intern (symbol-name item)))
+                                                 element))))))
+                              (cdr lambda-list))))
+               (unless (string-equal method-name 'describe-object)
+                 (format stream "- ~S~%"
+                         (if lambda-list-parameters
+                             (list method-name lambda-list-parameters)
+                             (list method-name)))))))
+      (format stream "Supported RPC methods:~2%")
+      (mapc #'proper-lambda-list
+	    (stable-sort (copy-list (closer-mop:specializer-direct-methods class))
+			 (lambda (method1 method2)
+			   (string-lessp (closer-mop:generic-function-name
+					  (closer-mop:method-generic-function method1))
+					 (closer-mop:generic-function-name
+					  (closer-mop:method-generic-function method2))))))
+      nil))
 
-  
-  (defun generate-client-class (class-name spec &key export-symbols)
+  (declaim (ftype (function (symbol &key (:export-symbols boolean))
+			    cons)
+		  generate-client-class))
+  (defun generate-client-class (class-name &key export-symbols)
     (let* ((make-func-name (alexandria:symbolicate "MAKE-" class-name))
-           (method-descriptions (mapcar #'generate-method-description
-                                        (gethash "methods" spec)))
            (result `((defclass ,class-name (jsonrpc/class:client)
                        ())
                      (defun ,make-func-name ()
                        (make-instance ',class-name))
-                     (defmethod describe-object ((client ,class-name) stream)
-                       (format stream "Supported RPC methods:~2%")
-                       ,@method-descriptions))))
+		     (defmethod describe-object ((client ,class-name) stream)
+		       (generate-method-descriptions (class-of client) stream)))))
       (when export-symbols
         (appendf result
                  `((export ',class-name)
@@ -425,8 +455,11 @@ lambda-list a separate defmethod."
 
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
+  (declaim (ftype (function (symbol hash-table &key (:export-symbols boolean))
+			    (values cons list list &optional))
+		  %generate-client))
   (defun %generate-client (class-name spec &key (export-symbols t))
-    (let* ((client-class (generate-client-class class-name spec :export-symbols export-symbols))
+    (let* ((client-class (generate-client-class class-name :export-symbols export-symbols))
            (object-classes
              ;; The map from package::symbol to a code which defines
              ;; a class for some complex object used as argument or

--- a/docs/changelog.lisp
+++ b/docs/changelog.lisp
@@ -13,6 +13,17 @@
                               "JSON"
                               "RPC"
                               "OSX"))
+  (0.9.3 2023-10-16
+	 "
+## Fixes
+
+A function `generate-method-descriptions` has been added. This function uses the mop
+for generating the method descriptions at run-time. Previously this happend at compile-time.
+The `generate-method-descriptions` is called from the generated specialized `describe-object`
+method. Now the output of `describe-object` should be correct again and show all generated,
+excluding the describe-object method itself.
+
+")
   (0.9.2 2023-10-15
 	   "
 ## Fixes

--- a/t/client/regress-data/multiple-types/client-class.lisp
+++ b/t/client/regress-data/multiple-types/client-class.lisp
@@ -1,5 +1,5 @@
 ((defclass the-class (jsonrpc/class:client) nil)
  (defun make-the-class () (make-instance 'the-class))
  (defmethod describe-object ((openrpc-client/core::client the-class) stream)
-   (format stream "Supported RPC methods:~2%")
-   (format stream "- ~S~%" '(example ((name string)) ((name null))))))
+   (openrpc-client/core::generate-method-descriptions
+    (class-of openrpc-client/core::client) stream)))


### PR DESCRIPTION
A function `generate-method-descriptions` has been added. This function uses the mop for generating the method descriptions at run-time. Previously this happened at compile-time. The `generate-method-descriptions` is called from the generated specialized `describe-object` method. Now the output of `describe-object` should be correct again and show all generated, excluding the `describe-object` method itself.

Also type declarations have been added to changed functions: `generate-method-descriptions`, `generate-client-class`, `%generate-client`.

Closes #12 