### PR TITLE
Feat: Support required param type object, boolean

### DIFF
--- a/docs/changelog.lisp
+++ b/docs/changelog.lisp
@@ -13,8 +13,15 @@
                               "JSON"
                               "RPC"
                               "OSX"))
-  (0.10.0 2023-10-17
-          "
+    (0.10.1 2023-10-17
+	    "
+## Additions
+
+- Support object and boolean type for required parameters.
+- Add regression tests for generated DESCRIBE-OBJECT method.
+")
+    (0.10.0 2023-10-17
+            "
 ## Changes
 
 Generic-function OPENRPC-SERVER/INTERFACE:MAKE-INFO now accepts only one argument - object of class OPENRPC-SERVER/API:API.

--- a/t/client/regress-data/multiple-types/methods.lisp
+++ b/t/client/regress-data/multiple-types/methods.lisp
@@ -24,4 +24,52 @@
                         openrpc-client/core::client "example"
                         openrpc-client/core::args)))
                   openrpc-client/core::raw-response)))
-       (openrpc-client/core::retrieve-data #:g2)))))
+       (openrpc-client/core::retrieve-data #:g2))))
+ (defgeneric example2
+     (openrpc-client/core::client param1 &key param-x)
+   (:documentation "Example method."))
+ (defmethod example2 ((openrpc-client/core::client the-class) (param1 null)
+		      &key (param-x nil param-x-given-p))
+   (let* ((#:g3
+            (let ((openrpc-client/core::args (make-hash-table :test 'equal)))
+              (setf (gethash "param1" openrpc-client/core::args) param1)
+              (when param-x-given-p
+                (setf (gethash "paramX" openrpc-client/core::args) param-x))
+              openrpc-client/core::args)))
+     (labels ((openrpc-client/core::retrieve-data (openrpc-client/core::args)
+		(let ((openrpc-client/core::raw-response
+                        (openrpc-client/core::rpc-call openrpc-client/core::client
+                                                       "example2"
+                                                       openrpc-client/core::args)))
+		  openrpc-client/core::raw-response)))
+       (openrpc-client/core::retrieve-data #:g3))))
+ (defmethod example2 ((openrpc-client/core::client the-class)
+		      (param1 (eql t)) &key (param-x nil param-x-given-p))
+   (let* ((#:g4
+            (let ((openrpc-client/core::args (make-hash-table :test 'equal)))
+              (setf (gethash "param1" openrpc-client/core::args) param1)
+              (when param-x-given-p
+                (setf (gethash "paramX" openrpc-client/core::args) param-x))
+              openrpc-client/core::args)))
+     (labels ((openrpc-client/core::retrieve-data (openrpc-client/core::args)
+		(let ((openrpc-client/core::raw-response
+                        (openrpc-client/core::rpc-call openrpc-client/core::client
+                                                       "example2"
+                                                       openrpc-client/core::args)))
+		  openrpc-client/core::raw-response)))
+       (openrpc-client/core::retrieve-data #:g4))))
+ (defgeneric example3
+     (openrpc-client/core::client param3)
+   (:documentation "Example method."))
+ (defmethod example3 ((openrpc-client/core::client the-class) (param3 list))
+   (let* ((#:g5
+            (let ((openrpc-client/core::args (make-hash-table :test 'equal)))
+              (setf (gethash "param3" openrpc-client/core::args) param3)
+              openrpc-client/core::args)))
+      (labels ((openrpc-client/core::retrieve-data (openrpc-client/core::args)
+                 (let ((openrpc-client/core::raw-response
+                        (openrpc-client/core::rpc-call openrpc-client/core::client
+                                                       "example3"
+                                                       openrpc-client/core::args)))
+                   openrpc-client/core::raw-response)))
+        (openrpc-client/core::retrieve-data #:g5)))))

--- a/t/client/regress-data/multiple-types/spec.json
+++ b/t/client/regress-data/multiple-types/spec.json
@@ -23,6 +23,58 @@
       }, 
       "summary": "Example method.",
       "paramStructure": "by-name"
+    },
+    {
+      "name": "example2",
+      "params": [
+        {
+          "name": "param1",
+          "schema":
+          {
+            "type": "boolean",
+          },
+          "required": true,
+          "summary": "User name."
+        },
+        {
+          "name": "paramX",
+          "schema":
+          {
+            "type": "array",
+          },
+          "summary": "X Parameter."
+        }
+      ],
+      "result": {
+        "name": "example_result2",
+        "schema": {
+          "type": "object",
+        }
+      },
+      "summary": "Example method.",
+      "paramStructure": "by-name"
+    },
+    {
+      "name": "example3",
+      "params": [
+        {
+          "name": "param3",
+          "schema":
+          {
+            "type": "array",
+          },
+          "required": true,
+          "summary": "User example3."
+        }
+      ],
+      "result": {
+        "name": "example_result3",
+        "schema": {
+          "type": "array",
+        }
+      },
+      "summary": "Example method.",
+      "paramStructure": "by-name"
     }
   ],
   "openrpc": "1.0.0",


### PR DESCRIPTION
Now the types "object" and "boolean" are supported for required parameters.
`Boolean` is implemented by creating one method with specializer `null` and
one with `eql-specializer` with object `t`.

Also: 
- change `generate-method-descriptions` function and `docstring` to
allow printing of `eql-specializer`.
- add regression test for `describe-object` and add more methods to `spec.json` for regression tests to cover required parameters of type `array` without items, `boolean` and `object`.