### PR TITLE
Removed jsonrpc dependency from asd file because it already present in openrpc-server/server defpackage.

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -27,38 +27,11 @@
           "uses": "actions/checkout@v3"
         },
         {
-          "name": "Grant All Perms to Make Cache Restoring Possible",
-          "run": "sudo mkdir -p /usr/local/etc/roswell\n                 sudo chown \"${USER}\" /usr/local/etc/roswell\n                 # Here the ros binary will be restored:\n                 sudo chown \"${USER}\" /usr/local/bin",
-          "shell": "bash"
-        },
-        {
-          "name": "Get Current Month",
-          "id": "current-month",
-          "run": "echo \"value=$(date -u \"+%Y-%m\")\" >> $GITHUB_OUTPUT",
-          "shell": "bash"
-        },
-        {
-          "name": "Cache Roswell Setup",
-          "id": "cache",
-          "uses": "actions/cache@v3",
-          "with": {
-            "path": "qlfile\nqlfile.lock\n~/.cache/common-lisp/\n~/.roswell\n/usr/local/etc/roswell\n/usr/local/bin/ros\n/usr/local/Cellar/roswell\n.qlot",
-            "key": "a-${{ steps.current-month.outputs.value }}-${{ env.cache-name }}-ubuntu-latest-quicklisp-sbcl-bin-${{ hashFiles('qlfile.lock', '*.asd') }}"
-          }
-        },
-        {
-          "name": "Restore Path To Cached Files",
-          "run": "echo $HOME/.roswell/bin >> $GITHUB_PATH\n                 echo .qlot/bin >> $GITHUB_PATH",
-          "shell": "bash",
-          "if": "steps.cache.outputs.cache-hit == 'true'"
-        },
-        {
           "name": "Setup Common Lisp Environment",
           "uses": "40ants/setup-lisp@v2",
           "with": {
             "asdf-system": "openrpc-server"
-          },
-          "if": "steps.cache.outputs.cache-hit != 'true'"
+          }
         },
         {
           "name": "Change dist to Ultralisp if qlfile does not exist",
@@ -120,39 +93,12 @@
           "uses": "actions/checkout@v3"
         },
         {
-          "name": "Grant All Perms to Make Cache Restoring Possible",
-          "run": "sudo mkdir -p /usr/local/etc/roswell\n                 sudo chown \"${USER}\" /usr/local/etc/roswell\n                 # Here the ros binary will be restored:\n                 sudo chown \"${USER}\" /usr/local/bin",
-          "shell": "bash"
-        },
-        {
-          "name": "Get Current Month",
-          "id": "current-month",
-          "run": "echo \"value=$(date -u \"+%Y-%m\")\" >> $GITHUB_OUTPUT",
-          "shell": "bash"
-        },
-        {
-          "name": "Cache Roswell Setup",
-          "id": "cache",
-          "uses": "actions/cache@v3",
-          "with": {
-            "path": "qlfile\nqlfile.lock\n~/.cache/common-lisp/\n~/.roswell\n/usr/local/etc/roswell\n/usr/local/bin/ros\n/usr/local/Cellar/roswell\n.qlot",
-            "key": "a-${{ steps.current-month.outputs.value }}-${{ env.cache-name }}-${{ matrix.os }}-ultralisp-${{ matrix.lisp }}-${{ hashFiles('qlfile.lock', '*.asd') }}"
-          }
-        },
-        {
-          "name": "Restore Path To Cached Files",
-          "run": "echo $HOME/.roswell/bin >> $GITHUB_PATH\n                 echo .qlot/bin >> $GITHUB_PATH",
-          "shell": "bash",
-          "if": "steps.cache.outputs.cache-hit == 'true'"
-        },
-        {
           "name": "Setup Common Lisp Environment",
           "uses": "40ants/setup-lisp@v2",
           "with": {
             "asdf-system": "openrpc-server",
             "qlfile-template": "{% ifequal quicklisp_dist \"ultralisp\" %}\ndist ultralisp http://dist.ultralisp.org\n{% endifequal %}"
-          },
-          "if": "steps.cache.outputs.cache-hit != 'true'"
+          }
         },
         {
           "name": "Run Tests",

--- a/openrpc-server.asd
+++ b/openrpc-server.asd
@@ -5,7 +5,7 @@
   :class :40ants-asdf-system
   :defsystem-depends-on ("40ants-asdf-system")
   :pathname "server"
-  :serial t
+  ;; :serial t
   :depends-on ("log4cl-extras"
                "openrpc-server/server"
                "openrpc-server/class"

--- a/openrpc-server.asd
+++ b/openrpc-server.asd
@@ -5,9 +5,7 @@
   :class :40ants-asdf-system
   :defsystem-depends-on ("40ants-asdf-system")
   :pathname "server"
-  ;; :serial t
-  :depends-on ("log4cl-extras"
-               "openrpc-server/server"
+  :depends-on ("openrpc-server/server"
                "openrpc-server/class"
                "openrpc-server/discovery")
   :description "OpenRPC server implementation for Common Lisp."

--- a/openrpc-server.asd
+++ b/openrpc-server.asd
@@ -7,7 +7,6 @@
   :pathname "server"
   :serial t
   :depends-on ("log4cl-extras"
-               "jsonrpc"
                "openrpc-server/server"
                "openrpc-server/class"
                "openrpc-server/discovery")

--- a/server/ci.lisp
+++ b/server/ci.lisp
@@ -18,7 +18,7 @@
   :on-push-to "master"
   :by-cron "0 10 * * 1"
   :on-pull-request t
-  :cache t
+  ;; :cache t
   :jobs ((40ants-ci/jobs/linter:linter :check-imports t)
          (run-tests
           :os ("ubuntu-latest"

--- a/server/method.lisp
+++ b/server/method.lisp
@@ -26,7 +26,6 @@
                 #:add-api-method
                 #:default-api
                 #:api-server)
-  (:import-from #:log4cl-extras)
   (:import-from #:log4cl-extras/error
                 #:with-log-unhandled)
   (:import-from #:jsonrpc)

--- a/server/method.lisp
+++ b/server/method.lisp
@@ -26,6 +26,7 @@
                 #:add-api-method
                 #:default-api
                 #:api-server)
+  (:import-from #:log4cl-extras)
   (:import-from #:log4cl-extras/error
                 #:with-log-unhandled)
   (:import-from #:jsonrpc)


### PR DESCRIPTION
Interesting that sometimes quicklisp fails to download jsonrpc when it loads openrpc-server and encounters
dependency from jsonrpc/transport/http. Probably the reason is that `:serial t` option in ASDF system definition
does not work with package-inferred systems?