### PR TITLE
Fix: Add necessary helpers for simple example

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,19 @@ First, we will operate on usual Common Lisp class:
         :type string
         :reader pet-tag)))
 ```
+
+Next we define some helpers:
+
+```lisp
+(defvar *pets* (make-hash-table :test 'equal))
+
+(defun get-new-id ()
+  (1+
+   (if (zerop (hash-table-count *pets*))
+       0
+       (apply #'max (alexandria:hash-table-keys *pets*)))))
+```
+
 Now we can define an `RPC` method to create a new pet:
 
 ```

--- a/docs/changelog.lisp
+++ b/docs/changelog.lisp
@@ -13,8 +13,13 @@
                               "JSON"
                               "RPC"
                               "OSX"))
-  (0.10.2 2023-11-17
+  (0.10.3 2023-11-21
           "
+## Fix
+
+Add necessary helpers for simple example in Readme.")
+  (0.10.2 2023-11-17
+	  "
 ## Fixes
 
 Fixed loading error occured in some cases when jsonrpc/transport/http was not found.


### PR DESCRIPTION
Now the simple example should work by just copying.