### PR TITLE
Chore: reorganize symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ For example, this macro call:
 Will generate the whole bunch of classes and methods:
 
 ```
-(defclass petshop (jsonrpc/class:client) nil)
+(defclass petshop (jsonrpc/client:client) nil)
 
 (defun make-petshop () (make-instance 'petshop))
 

--- a/client/docs.lisp
+++ b/client/docs.lisp
@@ -27,7 +27,7 @@ Will generate the whole bunch of classes and methods:
 
 
 ```
-(defclass petshop (jsonrpc/class:client) nil)
+(defclass petshop (jsonrpc/client:client) nil)
 
 (defun make-petshop () (make-instance 'petshop))
 

--- a/server/clack.lisp
+++ b/server/clack.lisp
@@ -3,7 +3,7 @@
   (:import-from #:jsonrpc)
   (:import-from #:yason)
   (:import-from #:lack.request)
-  (:import-from #:jsonrpc/class
+  (:import-from #:jsonrpc/server
                 #:bind-server-to-transport)
   (:import-from #:jsonrpc/transport/websocket
                 #:websocket-transport)

--- a/t/client/regress-data/multiple-types/client-class.lisp
+++ b/t/client/regress-data/multiple-types/client-class.lisp
@@ -1,4 +1,4 @@
-((defclass the-class (jsonrpc/class:client) nil)
+((defclass the-class (jsonrpc/client:client) nil)
  (defun make-the-class () (make-instance 'the-class))
  (defmethod describe-object ((openrpc-client/core::client the-class) stream)
    (openrpc-client/core::generate-method-descriptions


### PR DESCRIPTION
- jsonrpc restructured in recent changes.
  - call import from jsonrpc/base
  - client import from jsonrpc/client
  - bind-server-to-transport import from jsonrpc/server
- explicitly import-from symbols in openrpc-client/core and remove package qualifiers
- update README with jsonrpc/client:client